### PR TITLE
Changes in misc.py

### DIFF
--- a/detr/util/misc.py
+++ b/detr/util/misc.py
@@ -18,7 +18,7 @@ from torch import Tensor
 
 # needed due to empty tensor bug in pytorch and torchvision 0.5
 import torchvision
-if float(torchvision.__version__[:3]) < 0.7:
+if float(torchvision.__version__.split(".")[1]) < 7.0:
     from torchvision.ops import _new_empty_tensor
     from torchvision.ops.misc import _output_size
 
@@ -454,7 +454,7 @@ def interpolate(input, size=None, scale_factor=None, mode="nearest", align_corne
     This will eventually be supported natively by PyTorch, and this
     class can go away.
     """
-    if float(torchvision.__version__[:3]) < 0.7:
+    if float(torchvision.__version__.split(".")[1]) < 7.0:
         if input.numel() > 0:
             return torch.nn.functional.interpolate(
                 input, size, scale_factor, mode, align_corners


### PR DESCRIPTION
For preventing the error of `ImportError: cannot import name '_new_empty_tensor' from 'torchvision.ops'` I just change 2 lines that I believe came with the error from the Master of DETR repository. The issue [#417](https://github.com/facebookresearch/detr/issues/417) is solved by the same way of [#404](https://github.com/facebookresearch/detr/pull/404)