### PR TITLE
Update numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 funcy==1.15
-numpy==1.21.0
+numpy>=1.21
 scikit-learn==0.23.2
 scipy==1.5.2
 iterative-stratification==0.1.6


### PR DESCRIPTION
A Buffer Overflow vulnerability exists in NumPy 1.9.x in the PyArray_NewFromDescr_int function of ctors.c when specifying arrays of large dimensions (over 32) from Python code, which could let a malicious user cause a Denial of Service.